### PR TITLE
fix flaky test

### DIFF
--- a/oak-auth-ldap/src/test/java/org/apache/jackrabbit/oak/security/authentication/ldap/impl/UseUidForExtIdTest.java
+++ b/oak-auth-ldap/src/test/java/org/apache/jackrabbit/oak/security/authentication/ldap/impl/UseUidForExtIdTest.java
@@ -46,6 +46,8 @@ public class UseUidForExtIdTest extends AbstractLdapIdentityProviderTest {
         ExternalIdentity id = idp.getIdentity(ref);
         assertTrue("User instance", id instanceof ExternalUser);
         assertEquals("User ID", TEST_USER1_UID, id.getId());
+        ref = null;
+        id = null;
     }
 
     @Test


### PR DESCRIPTION
### What is the purpose of this PR?
The purpose of the PR is to fix the flaky test that exists in the present tests. The flaky tests are failing with Nondex tools.

### Why did the test fail?
Seems like the external environment is polluting the assertion variables or running tests on different orders(shuffling) may result in the inconsistency of the existing test.

### Expected results
The test must be free from flaky tests.

### Actual results
It's detecting the flaky tests.

### Description of fix
We will set the value of the variables to `null` which can help prevent contamination from external variables/environments and help run running tests in different orders. By resetting the value, it is possible to access and manipulate it without affecting other elements in the test suite. This approach helps ensure accurate and reliable test results.